### PR TITLE
Update spree_core.gemspec to update kt-paperclip version

### DIFF
--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'highline', '~> 1.6.18' # Necessary for the install generator
   s.add_dependency 'kaminari', '~> 1.0.1'
   s.add_dependency 'monetize', '~> 1.1'
-  s.add_dependency 'kt-paperclip', '~> 5.4.0'
+  s.add_dependency 'kt-paperclip', '~> 6.0.0'
   s.add_dependency 'paranoia', '~> 2.3.0'
   s.add_dependency 'premailer-rails'
   s.add_dependency 'acts-as-taggable-on', '~> 5.0'


### PR DESCRIPTION
* Upgrade to v6.0.0 
* v5.4.0 expects aws-sdk gem, while v6.0.0 expects only aws-sdk-s3